### PR TITLE
ffmemless: Rename settings environment variable

### DIFF
--- a/data/plugins.d/ffmemless.ini
+++ b/data/plugins.d/ffmemless.ini
@@ -4,7 +4,7 @@
 # The if there are parameters for any effects in the system settings file
 # pointed by the given environment variable, they will override the effect
 # settings for those effects. Other effects remain unchanged.
-system_effects_env = FF_MEMLESS_SETTINGS
+system_effects_env = NGF_FFMEMLESS_SETTINGS
 
 # EXAMPLE: re-define NGF_SHORT in system settings file
 # export FF_MEMLESS_SETTINGS=/path/to/my/feedback.ini


### PR DESCRIPTION
The original plan for the settings environment variable was that
we could use the same settings file for qtfeedback and ngfd.
Unfortunately QSettings cannot read glib's .ini file format,
and vice versa glib cannot comprehend settings values without
bracket header.

So, change the ngf environment variable to be different from
the qtfeedback one, so that separate device/distro specific values
can be set in separate files for qtfeedback and ngfd.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jollamobile.com
