### PR TITLE
[build] Fix int/gpointer type conversion

### DIFF
--- a/src/ngf/core.c
+++ b/src/ngf/core.c
@@ -671,7 +671,7 @@ n_core_parse_keytypes (NCore *core, GKeyFile *keyfile)
         }
 
         N_DEBUG (LOG_CAT "new key type '%s' = %s", *key, value);
-        g_hash_table_replace (core->key_types, g_strdup (*key), (gpointer) key_type);
+        g_hash_table_replace (core->key_types, g_strdup (*key), GINT_TO_POINTER(key_type));
         g_free (value);
     }
 
@@ -913,7 +913,7 @@ n_core_connect (NCore *core, NCoreHook hook, int priority,
     if (hook >= N_CORE_HOOK_LAST)
         return FALSE;
 
-    N_DEBUG (LOG_CAT "0x%X connected to hook '%s'", (unsigned int) callback,
+    N_DEBUG (LOG_CAT "0x%p connected to hook '%s'", callback,
         n_core_hook_to_string (hook));
 
     n_hook_connect (&core->hooks[hook], priority, callback, userdata);

--- a/src/ngf/event.c
+++ b/src/ngf/event.c
@@ -147,7 +147,7 @@ n_event_parse_properties (GKeyFile *keyfile, const char *group,
 
     key_list = g_key_file_get_keys (keyfile, group, NULL, NULL);
     for (key = key_list; *key; ++key) {
-        key_type = (int) g_hash_table_lookup (keytypes, *key);
+        key_type = GPOINTER_TO_INT(g_hash_table_lookup (keytypes, *key));
 
         switch (key_type) {
             case N_VALUE_TYPE_INT:

--- a/src/ngf/value.c
+++ b/src/ngf/value.c
@@ -273,7 +273,7 @@ n_value_to_string (const NValue *value)
             break;
 
         case N_VALUE_TYPE_POINTER:
-            result = g_strdup_printf ("0x%X (pointer)", (unsigned int) value->value.p);
+            result = g_strdup_printf ("0x%p (pointer)", value->value.p);
             break;
 
         default:

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -276,7 +276,7 @@ START_TEST (test_to_string)
 
     n_value_set_pointer (value, point);
     string = n_value_to_string (value);
-    expected = g_strdup_printf ("0x%X (pointer)", (unsigned int)point);
+    expected = g_strdup_printf ("0x%p (pointer)", point);
     fail_unless (g_strcmp0 (string, expected) == 0);
     g_free (string);
     g_free (expected);


### PR DESCRIPTION
This patch uses the glib conversion macros to covert between int and gpointer.
This now builds on all Mer arches including x86_64.
