### PR TITLE
[gst] Support media.role in event configuration file

### DIFF
--- a/src/plugins/gst/plugin.c
+++ b/src/plugins/gst/plugin.c
@@ -264,9 +264,12 @@ create_stream_properties (NProplist *props)
 
     set_structure_string (s, "media.filename", source);
 
-    /* set a media.role to "media" */
-
-    set_structure_string (s, "media.role", "media");
+    /* set media.role from configuration file if defined. Default to "media" */
+    role = n_proplist_get_string (props, STREAM_PREFIX_KEY "media.role");
+    if (role)
+        set_structure_string (s, "media.role", role);
+    else
+        set_structure_string (s, "media.role", "media");
 
     /* if system sound level is off and the flag is set, then we need to
        use different stream restore role. */


### PR DESCRIPTION
By default gst plugin use media.role=media.
When another media.role is needed it can be configured in event file in /usr/share/ngfd/events.d/

For example:
sound.stream.media.role = mymedia
