### PR TITLE
[ffmemless] Add check for device existence to plugin loading

### DIFF
--- a/src/plugins/ffmemless/plugin.c
+++ b/src/plugins/ffmemless/plugin.c
@@ -659,6 +659,7 @@ N_PLUGIN_LOAD(plugin)
 {
 	const NProplist *props = n_plugin_get_params(plugin);
 	const gchar *system_settings_file;
+	int device_fd;
 
 	N_DEBUG (LOG_CAT "plugin load");
 
@@ -672,6 +673,14 @@ N_PLUGIN_LOAD(plugin)
 		.pause      = ffm_sink_pause,
 		.stop       = ffm_sink_stop
 	};
+
+	/* Checking if there is a device, no point in loading plugin if not..*/
+	device_fd = ffmemless_evdev_file_search();
+	if (device_fd < 0) {
+		N_DEBUG (LOG_CAT "No force feedback device, stopping plugin");
+		return FALSE;
+	}
+	ffmemless_evdev_file_close(device_fd);
 
 	ffm.ngfd_props = props;
 	system_settings_file = g_getenv(n_proplist_get_string(props,


### PR DESCRIPTION
Ngfd fails to run in SDK as there is no ffmemless device, and
a sink failing init will stop whole ngfd from working. Added
a check to plugin load for the device existance, so we don't
even load the plugin if we can't run it.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jollamobile.com
