### PR TITLE
[haptic] Make haptic policy (settings, calls) reusable

### DIFF
--- a/src/include/ngf/Makefile.am
+++ b/src/include/ngf/Makefile.am
@@ -11,5 +11,6 @@ library_include_HEADERS = \
     sinkinterface.h \
     value.h \
     core-hooks.h \
+    haptic.h \
     hook.h
 

--- a/src/include/ngf/haptic.h
+++ b/src/include/ngf/haptic.h
@@ -1,0 +1,51 @@
+
+/*
+ * ngfd - Non-graphic feedback daemon
+ * Haptic feedback support functions
+ *
+ * Copyright (C) 2014 Jolla Ltd.
+ * Contact: Thomas Perl <thomas.perl@jolla.com>
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef N_NGF_HAPTIC_H
+#define N_NGF_HAPTIC_H
+
+#include <ngf/log.h>
+#include <ngf/proplist.h>
+#include <ngf/core.h>
+#include <ngf/sinkinterface.h>
+#include <ngf/inputinterface.h>
+
+/**
+ * Convenience function to filter haptic depending on settings and call state
+ *
+ * This function should be used by all haptic feedback plugins in their
+ * _sink_can_handle() function to determine whether the event should be
+ * played or not. It will take care of returning FALSE in case vibration
+ * feedback is diabled or if phone calls are active. If it returns TRUE,
+ * the plugin can do additional checks (e.g. whether or not it has an
+ * effect for the request). The interface is kept in line with the
+ * definition in NSinkInterfaceDecl, so in case the plugin does not have
+ * to do any special casing, it can be used there directly.
+ *
+ * @param iface Pointer to a NSinkInterface
+ * @param request Pointer to a NRequest
+ * @return FALSE if the plugin should not handle this event, TRUE otherwise
+ */
+int n_haptic_can_handle (NSinkInterface *iface, NRequest *request);
+
+#endif /* N_NGF_HAPTIC_H */

--- a/src/ngf/Makefile.am
+++ b/src/ngf/Makefile.am
@@ -13,6 +13,7 @@ ngfd_SOURCES =                \
     core.c                    \
     core-hooks.h              \
     core-hooks.c              \
+    haptic.c                  \
     hook.h                    \
     hook.c                    \
     core-player.h             \

--- a/src/ngf/haptic.c
+++ b/src/ngf/haptic.c
@@ -1,0 +1,78 @@
+
+/*
+ * ngfd - Non-graphic feedback daemon
+ * Haptic feedback support functions
+ *
+ * Copyright (C) 2014 Jolla Ltd.
+ * Contact: Thomas Perl <thomas.perl@jolla.com>
+ *
+ * Based on code from the ffmemless plugin:
+ * Copyright (C) 2013 Jolla Oy.
+ * Contact: Kalle Jokiniemi <kalle.jokiniemi@jollamobile.com>
+ *
+ * This work is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This work is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this work; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+
+#include <ngf/haptic.h>
+#include <string.h>
+
+#define LOG_CAT "haptic: "
+
+
+int
+n_haptic_can_handle (NSinkInterface *iface, NRequest *request)
+{
+    NCore    *core    = n_sink_interface_get_core     (iface);
+    NContext *context = n_core_get_context            (core);
+    NValue   *enabled = NULL;
+    NValue   *touch_level = NULL;
+    NValue   *call_state = NULL;
+
+    N_DEBUG (LOG_CAT "can handle %s?", n_request_get_name(request));
+
+    enabled = (NValue*) n_context_get_value (context,
+            "profile.current.vibrating.alert.enabled");
+    touch_level = (NValue*) n_context_get_value (context,
+            "profile.current.touchscreen.vibration.level");
+
+    call_state = (NValue*) n_context_get_value (context,
+            "call_state.mode");
+
+    if (touch_level == NULL) {
+        N_WARNING (LOG_CAT "No value for touchscreen.vibration.level!");
+    }
+
+    if (call_state == NULL) {
+        N_WARNING (LOG_CAT "Call state not available!");
+    }
+
+    if (!enabled || !n_value_get_bool (enabled)) {
+        N_DEBUG (LOG_CAT "no, vibration disabled in profile");
+        return FALSE;
+    }
+
+    if (call_state && !strcmp(n_value_get_string(call_state), "active")) {
+        N_DEBUG (LOG_CAT "no, should not vibrate during call");
+        return FALSE;
+    }
+
+    if (n_value_get_int(touch_level) == 0) {
+        N_DEBUG (LOG_CAT "No, touch vibra level at 0, skipping vibra");
+        return FALSE;
+    }
+
+    return TRUE;
+}


### PR DESCRIPTION
Extract the settings and call handling from the ffmemless
plugin to a reusable function in haptic.{c,h} for use by
other plugins.
