### PR TITLE
haptic: Use event configuration based haptic event type detection

### DIFF
--- a/data/events.d/accessory_connected.ini
+++ b/data/events.d/accessory_connected.ini
@@ -2,3 +2,4 @@
 sound.filename = /usr/share/sounds/ui-tones/snd_accessory_connected.wav
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/accessory_disconnected.ini
+++ b/data/events.d/accessory_disconnected.ini
@@ -2,3 +2,4 @@
 sound.filename = /usr/share/sounds/ui-tones/snd_accessory_disconnected.wav
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/battery_low.ini
+++ b/data/events.d/battery_low.ini
@@ -4,6 +4,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_BATTERYLOW
 sound.stream.event.id = event-in-call
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm
 
 [battery_low]
 sound.filename = /usr/share/sounds/ui-tones/snd_battery_low.wav
@@ -11,3 +12,4 @@ immvibe.filename = /usr/share/sounds/vibra/tct_battery_low.ivt
 ffmemless.effect = NGF_BATTERYLOW
 sound.stream.event.id = event-in-call
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/calendar.ini
+++ b/data/events.d/calendar.ini
@@ -4,6 +4,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = event-in-call
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [calendar => play.mode=short]
 sound.filename = /usr/share/sounds/ui-tones/snd_in_call_beep.wav
@@ -11,6 +12,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = event-in-call
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [calendar]
 sound.profile = calendar.alert.tone => sound.filename
@@ -21,3 +23,4 @@ immvibe.lookup = true
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = alarm-clock-elapsed
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/charging_started.ini
+++ b/data/events.d/charging_started.ini
@@ -3,3 +3,4 @@ immvibe.filename = filename:/usr/share/sounds/vibra/tct_charging_started.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/chat.ini
+++ b/data/events.d/chat.ini
@@ -4,6 +4,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [chat => play.mode=short]
 sound.filename = /usr/share/sounds/ui-tones/snd_default_beep.wav
@@ -11,6 +12,7 @@ sound.stream.event.id = event-in-call
 immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [chat]
 sound.profile = im.alert.tone@general => sound.filename
@@ -21,3 +23,4 @@ immvibe.lookup = true
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/chat_fg.ini
+++ b/data/events.d/chat_fg.ini
@@ -4,3 +4,4 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/clock.ini
+++ b/data/events.d/clock.ini
@@ -4,6 +4,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = event-in-call
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [clock]
 sound.profile = clock.alert.tone => sound.filename
@@ -16,3 +17,4 @@ sound.stream.event.id = alarm-clock-elapsed
 sound.stream.module-stream-restore.id = x-meego-full-volume
 sound.volume = linear:10;100;15
 sound.repeat = true
+haptic.type = alarm

--- a/data/events.d/email.ini
+++ b/data/events.d/email.ini
@@ -4,6 +4,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [email => play.mode=short]
 sound.filename = /usr/share/sounds/ui-tones/snd_default_beep.wav
@@ -11,6 +12,7 @@ sound.stream.event.id = event-in-call
 immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [email]
 sound.profile = email.alert.tone@general => sound.filename
@@ -21,3 +23,4 @@ immvibe.lookup = true
 ffmemless.effect = NGF_LONG
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/information_snd.ini
+++ b/data/events.d/information_snd.ini
@@ -2,3 +2,4 @@
 sound.filename = /usr/share/sounds/ui-tones/snd_information.wav
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/information_strong.ini
+++ b/data/events.d/information_strong.ini
@@ -4,3 +4,4 @@ immvibe.filename = /usr/share/sounds/vibra/tct_information_strong.ivt
 ffmemless.effect = NGF_STRONG
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/information_tacticon.ini
+++ b/data/events.d/information_tacticon.ini
@@ -2,3 +2,4 @@
 immvibe.filename = /usr/share/sounds/vibra/tct_information.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
+haptic.type = alarm

--- a/data/events.d/recharge_battery.ini
+++ b/data/events.d/recharge_battery.ini
@@ -4,6 +4,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = event-in-call
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm
 
 [recharge_battery]
 sound.filename = /usr/share/sounds/ui-tones/snd_recharge_battery.wav
@@ -11,3 +12,4 @@ immvibe.filename = /usr/share/sounds/vibra/tct_recharge_battery.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = event-in-call
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/ringtone.ini
+++ b/data/events.d/ringtone.ini
@@ -9,6 +9,7 @@ ffmemless.effect = NGF_SHORT
 
 sound.stream.event.id = phone-incoming-call
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 # If play.mode is short, then there is a higher priority event
 # active (call, video recording). Tone-generator should play the
@@ -19,6 +20,7 @@ sound.stream.module-stream-restore.id = x-meego-ringing-volume
 tonegen.pattern = 79
 tonegen.volume  = -5
 ffmemless.effect = NGF_SHORT
+haptic.type = alarm
 
 # Default ringtone event.
 
@@ -33,3 +35,4 @@ immvibe.lookup   = true
 
 sound.stream.event.id = phone-incoming-call
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/sms.ini
+++ b/data/events.d/sms.ini
@@ -4,6 +4,7 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 [sms => play.mode=short]
 sound.filename = /usr/share/sounds/ui-tones/snd_message_in_call.wav
@@ -11,6 +12,7 @@ sound.stream.event.id = event-in-call
 immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 # Default sms event.
 [sms]
@@ -22,3 +24,4 @@ immvibe.lookup = true
 ffmemless.effect = NGF_SMS
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/sms_fg.ini
+++ b/data/events.d/sms_fg.ini
@@ -4,3 +4,4 @@ immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt
 ffmemless.effect = NGF_SHORT
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/voip_ringtone.ini
+++ b/data/events.d/voip_ringtone.ini
@@ -9,6 +9,7 @@ ffmemless.effect = NGF_SHORT
 
 sound.stream.event.id = phone-incoming-call
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm
 
 # If play.mode is short, then there is a higher priority event
 # active (call, video recording). Tone-generator should play the
@@ -18,6 +19,7 @@ sound.stream.module-stream-restore.id = x-meego-ringing-volume
 [voip_ringtone => play.mode=short]
 tonegen.pattern = 79
 tonegen.volume  = -5
+haptic.type = alarm
 
 [voip_ringtone]
 sound.profile    = voip.alert.tone => sound.filename
@@ -30,3 +32,4 @@ ffmemless.effect = NGF_RINGTONE
 
 sound.stream.event.id = phone-incoming-call
 sound.stream.module-stream-restore.id = x-meego-ringing-volume
+haptic.type = alarm

--- a/data/events.d/warning_snd.ini
+++ b/data/events.d/warning_snd.ini
@@ -2,3 +2,4 @@
 sound.filename = /usr/share/sounds/ui-tones/snd_warning.wav
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/warning_strong.ini
+++ b/data/events.d/warning_strong.ini
@@ -4,3 +4,4 @@ immvibe.filename = /usr/share/sounds/vibra/tct_warning_strong.ivt
 ffmemless.effect = NGF_STRONG
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/events.d/warning_tacticon.ini
+++ b/data/events.d/warning_tacticon.ini
@@ -2,3 +2,4 @@
 immvibe.filename = /usr/share/sounds/vibra/tct_warning.ivt
 ffmemless.effect = NGF_LONG
 sound.stream.event.id = message-new-email
+haptic.type = alarm

--- a/data/events.d/wrong_charger.ini
+++ b/data/events.d/wrong_charger.ini
@@ -4,3 +4,4 @@ immvibe.filename = /usr/share/sounds/vibra/tct_warning.ivt
 ffmemless.effect = NGF_LONG
 sound.stream.event.id = message-new-email
 sound.stream.module-stream-restore.id = x-meego-system-sound-level
+haptic.type = alarm

--- a/data/plugins.d/ffmemless.ini
+++ b/data/plugins.d/ffmemless.ini
@@ -37,11 +37,6 @@ supported_effects = NGF_SHORT;NGF_LONG;NGF_STRONG;NGF_BATTERYLOW;NGF_RINGTONE;NG
 #		Please note that if the event has "sound.repeat" enabled,
 #		the effect is repeated until stop signal regardless of _REPEAT
 #		value.
-# _TOUCH =	[0, 1], Defines if a effect is related to touch screen
-#		interaction. If effect is touch related, the
-#		touch.vibration.level in current profile is followed to
-#		determine whether the effect should be played or not.
-#		Defaults to 0 (not a touch related effect)
 #
 # - Type specific parameters for rumble effects:
 #

--- a/src/include/ngf/haptic.h
+++ b/src/include/ngf/haptic.h
@@ -31,6 +31,26 @@
 #include <ngf/inputinterface.h>
 
 /**
+ * The haptic.type key tells what kind of haptic event this is
+ *
+ * Each bracketed event definition in events.d config files that needs
+ * haptic/vibra playback should contain "haptic.type" line to define what kind
+ * of haptic event it is.
+ *
+ * Supported type strings are currently:
+ *   "alarm" - for most vibration effects
+ *   "touch" - for events that only play when user touches touchscreen.
+ *
+ * The haptic event type is used to filter out playback in case user has
+ * disabled the setting for certain type of haptic feedback.
+ */
+#define HAPTIC_TYPE_KEY	"haptic.type"
+
+/* Convenience macros for supported haptic types */
+#define HAPTIC_TYPE_ALARM	"alarm"
+#define HAPTIC_TYPE_TOUCH	"touch"
+
+/**
  * Convenience function to filter haptic depending on settings and call state
  *
  * This function should be used by all haptic feedback plugins in their

--- a/src/ngf/haptic.c
+++ b/src/ngf/haptic.c
@@ -35,18 +35,24 @@
 int
 n_haptic_can_handle (NSinkInterface *iface, NRequest *request)
 {
-    NCore    *core    = n_sink_interface_get_core     (iface);
-    NContext *context = n_core_get_context            (core);
-    NValue   *enabled = NULL;
-    NValue   *touch_level = NULL;
-    NValue   *call_state = NULL;
+    NCore           *core = n_sink_interface_get_core (iface);
+    NContext        *context = n_core_get_context (core);
+    const NProplist *props = n_request_get_properties (request);
+    NValue          *enabled = NULL;
+    NValue          *touch_level = NULL;
+    NValue          *call_state = NULL;
+    const char      *haptic_type = NULL;
+    const char      *event_name = n_request_get_name (request);
 
-    N_DEBUG (LOG_CAT "can handle %s?", n_request_get_name(request));
+    N_DEBUG (LOG_CAT "can handle %s?", event_name);
 
     enabled = (NValue*) n_context_get_value (context,
             "profile.current.vibrating.alert.enabled");
     touch_level = (NValue*) n_context_get_value (context,
             "profile.current.touchscreen.vibration.level");
+
+    haptic_type =  n_proplist_get_string (props,
+            HAPTIC_TYPE_KEY);
 
     call_state = (NValue*) n_context_get_value (context,
             "call_state.mode");
@@ -59,17 +65,23 @@ n_haptic_can_handle (NSinkInterface *iface, NRequest *request)
         N_WARNING (LOG_CAT "Call state not available!");
     }
 
+    if (haptic_type == NULL) {
+        N_DEBUG (LOG_CAT "Haptic type not defined for %s", event_name);
+    }
+
     if (!enabled || !n_value_get_bool (enabled)) {
         N_DEBUG (LOG_CAT "no, vibration disabled in profile");
         return FALSE;
     }
 
-    if (call_state && !strcmp(n_value_get_string(call_state), "active")) {
+    if (call_state && !strcmp (n_value_get_string (call_state), "active")) {
         N_DEBUG (LOG_CAT "no, should not vibrate during call");
         return FALSE;
     }
 
-    if (n_value_get_int(touch_level) == 0) {
+    if (haptic_type &&
+                !strcmp (haptic_type, HAPTIC_TYPE_TOUCH) &&
+                n_value_get_int (touch_level) == 0) {
         N_DEBUG (LOG_CAT "No, touch vibra level at 0, skipping vibra");
         return FALSE;
     }

--- a/src/plugins/ffmemless/plugin.c
+++ b/src/plugins/ffmemless/plugin.c
@@ -51,14 +51,13 @@
 
 N_PLUGIN_NAME(FFM_PLUGIN_NAME)
 N_PLUGIN_DESCRIPTION("Vibra plugin using ff-memless kernel backend")
-N_PLUGIN_VERSION("0.9")
+N_PLUGIN_VERSION("0.10")
 
 struct ffm_effect_data {
 	NRequest       *request;
 	NSinkInterface *iface;
 	int id;
 	int repeat;
-	int touch_effect;
 	guint playback_time;
 	int poll_id;
 };
@@ -339,9 +338,6 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 
 		data->repeat = ffm_get_int_value(props, key, "_REPEAT", 1,
 								 INT32_MAX);
-		data->touch_effect = ffm_get_int_value(props, key, "_TOUCH", 0,
-								 1);
-		N_DEBUG (LOG_CAT "Got touch_effect = %d", data->touch_effect);
 
 		ff.replay.delay = ffm_get_int_value(props, key,
 						"_DELAY", 0, UINT16_MAX);


### PR DESCRIPTION
The ffmemless plugin was using effect configuration based *_TOUCH key
to detect if effect is touch interaction related to filter it out
in case touch haptics is disabled from profile. This got broken when
the can_handle policy was moved to haptic.c. And also it was never
working for android vibrator plugin.

Fixed the touch haptic detection by replacing the ffmemless specific
key with a event configuration based "haptic.type" key that will apply
right policy to all vibra plugins utilizing n_haptic_can_handle function.

The haptic.key currently supports type strings "alarm" and "touch". This
may be appended in the future if there is some need.

Currently default policy does not block haptic playback if "haptic.type"
key is missing for event, but it may be used for that in the future to
for example move the call state handling from haptic.c to event
configuration files, like it's done for audio now.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
