### PR TITLE
[ngfd] adjust the volume value we get from GStreamer before using it …

### DIFF
--- a/src/plugins/gst/plugin.c
+++ b/src/plugins/gst/plugin.c
@@ -179,7 +179,11 @@ get_current_volume (StreamData *stream, gdouble *out_volume)
     g_object_get (G_OBJECT (stream->volume),
         "volume", &v, NULL);
 
-    *out_volume = v;
+    /* GStreamer volume element ranges from 0 to 10 and the value of the GObject property
+     * is what has been set by GstController times 10. We need to divide the value by 10
+     * in order to set the correct volume for GstController
+     */
+    *out_volume = v/10;
 
     return TRUE;
 }


### PR DESCRIPTION
…again. Contributes to JB#29541

The value we get from GstVolume is the value set by GstController times 10 so we need to account for that