### PR TITLE
Divide fade values by 1000.0.

### DIFF
--- a/src/plugins/gst/plugin.c
+++ b/src/plugins/gst/plugin.c
@@ -702,8 +702,8 @@ parse_volume_fade (const char *str)
             effect->elapsed  = 0;
             effect->position = position;
             effect->length   = length;
-            effect->start    = start / 100.0;
-            effect->end      = end / 100.0;
+            effect->start    = start / 1000.0;
+            effect->end      = end / 1000.0;
         }
     }
 


### PR DESCRIPTION
GStreamer volume element ranges from 0 to 10 so to get values 0...1 for
fade effects we need to divide the input values by 1000 instead of 100.